### PR TITLE
Fix typo in the drupalfr events module.

### DIFF
--- a/www7/sites/all/modules/custom/drupalfr/drupalfr_events/drupalfr_events.module
+++ b/www7/sites/all/modules/custom/drupalfr/drupalfr_events/drupalfr_events.module
@@ -94,7 +94,7 @@ function drupalfr_events_fetch_events($items = 5) {
     }
   }
   else {
-    watchdog('events_meetup', 'Error parsing the meetup feed. @reponse', array('@response' => $response));
+    watchdog('events_meetup', 'Error parsing the meetup feed. @response', array('@response' => $response));
     return FALSE;
   }
 }


### PR DESCRIPTION
Bonjour,

En cherchant comment fonctionne le blocs des prochains meetup, je suis tombé sur une petite erreur de typo dans un message d'erreur pour le watchdog.