### PR TITLE
Add a basic integration with an optionally installed traefik proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ node_modules
 *.css.map
 
 # Docker.
+/.env
 docker-compose.yml
 /data
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ cd ..
 
 The website **should** be located at this address: `http://127.0.0.1:8101/*`
 
+#### Traefik integration
+
+If there's a local traefik reverse-proxy on your development environment, you
+can access the site through http://drupalfr.docker/
+
+An alternative hostname can be provided by setting the 
+DRUPAL_TRAEFIK_FRONTEND_RULE_HOSTNAME environment variable, for instance
+using a .env file. 
+
 ### Notes about configuration
 
 We have switched from Features to Config split, Config ignore, Config installer.

--- a/conf/drupal/default/example.settings.local.php
+++ b/conf/drupal/default/example.settings.local.php
@@ -12,6 +12,7 @@ $databases['default']['default'] = [
 $settings['hash_salt'] = 'drupalfr';
 $settings['trusted_host_patterns'] = [
   '^127\.0\.0\.1$',
+  getenv('DRUPAL_TRAEFIK_FRONTEND_RULE_HOSTNAME'),
   'varnish',
   'web',
 ];

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.3"
 
 services:
   httpd:

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -1,12 +1,16 @@
-version: "2"
+version: "2.3"
 
 services:
   web:
     extends:
       file: ./docker-compose-common.yml
       service: drupal-php-apache-dev
+    environment:
+      - DRUPAL_TRAEFIK_FRONTEND_RULE_HOSTNAME=${DRUPAL_TRAEFIK_FRONTEND_RULE_HOSTNAME:-drupalfr.docker}
     ports:
       - 8101:80
+    labels:
+      - traefik.frontend.rule=Host:${DRUPAL_TRAEFIK_FRONTEND_RULE_HOSTNAME:-drupalfr.docker}
     depends_on:
       - mysql
       - redis


### PR DESCRIPTION
Voila une première approche pour https://github.com/Drupal-FR/site-drupalfr/issues/27.

Mon point de vue est que ce n'est pas au projet de fournir une configuration pour `traefik` lui même car cela touche à la configuration système de la machine du développeur et concerne l'ensemble des projets dockerisés qui y tournent. De plus, on a à mon avis pas à imposer l'hostname que le developpeur souhaite utiliser.

On va plutôt documenter des guidelines (README ? wiki ?) pour que les personnes qui veulent le mettre en place puissent le faire.

Le projet fournit donc une intégration "par défaut" avec l'URL http://drupalfr.docker (on peut en discuter) donc fonctionne out of the box pour ceux qui on un `traefik` local avec un wildcard DNS `*.docker`.

Pour paramétrer un autre hostname, il suffit de setter la variable `DRUPAL_TRAEFIK_FRONTEND_RULE_HOSTNAME` dans un ficher  .env à la racine du projet.

L'hostname est dynamiquement injecté dans les `trusted_host_patterns`.