### PR TITLE
Update trusted_host_patterns for Varnish.

### DIFF
--- a/conf/drupal/default/example.settings.local.php
+++ b/conf/drupal/default/example.settings.local.php
@@ -12,12 +12,19 @@ $databases['default']['default'] = [
 $settings['hash_salt'] = 'drupalfr';
 $settings['trusted_host_patterns'] = [
   '^127\.0\.0\.1$',
-  'varnish',
-  'web',
+  '^varnish$',
+  '^web$',
 ];
 
-if (getenv('DRUPAL_TRAEFIK_FRONTEND_RULE_HOSTNAME')) {
-  $settings['trusted_host_patterns'][] = getenv('DRUPAL_TRAEFIK_FRONTEND_RULE_HOSTNAME');
+$environment_trusted_host_patterns = [
+  'DRUPAL_TRAEFIK_FRONTEND_RULE_HOSTNAME',
+  'VARNISH_TRAEFIK_FRONTEND_RULE_HOSTNAME',
+];
+
+foreach ($environment_trusted_host_patterns as $environment_trusted_host_pattern) {
+  if (getenv($environment_trusted_host_pattern)) {
+    $settings['trusted_host_patterns'][] = getenv($environment_trusted_host_pattern);
+  }
 }
 
 $settings['file_private_path'] = '/project/private_files/default';

--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -7,6 +7,7 @@ services:
       service: drupal-php-apache-dev
     environment:
       - DRUPAL_TRAEFIK_FRONTEND_RULE_HOSTNAME=${DRUPAL_TRAEFIK_FRONTEND_RULE_HOSTNAME:-web.drupalfr8.docker.localhost}
+      - VARNISH_TRAEFIK_FRONTEND_RULE_HOSTNAME=${VARNISH_TRAEFIK_FRONTEND_RULE_HOSTNAME:-varnish.drupalfr8.docker.localhost}
     ports:
       - 8101:80
     labels:


### PR DESCRIPTION
J'ai remarqué que lorsqu'on accède par varnish.drupalfr8.docker.localhost ça marche alors que ce n'est pas explicitement dans le trusted_host_patterns. Dû à la ligne varnish.

Là au moins, il y a moins de hasard et si l'url du Varnish ne contient pas Varnish ça continuera à fonctionner.