### PR TITLE
Add a script to generate assets.

### DIFF
--- a/scripts/generate-assets.sh
+++ b/scripts/generate-assets.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# You should have the following tools installed globally:
+# - npm
+
+usage() {
+    echo "generate-assets.sh build|watch"
+}
+
+while getopts "h" opt; do
+    case "${opt}" in
+        h)
+            usage; exit 0;;
+        \?)
+            usage >&2; exit 1;;
+    esac
+done
+
+if [ -z "$1" ]
+then
+    ASSETS_MODE='build'
+else
+    ASSETS_MODE="$1"
+fi
+
+. $(dirname ${BASH_SOURCE[0]})/script-parameters.sh
+. $(dirname ${BASH_SOURCE[0]})/script-parameters.local.sh
+
+echo -e "${LIGHT_GREEN}Change temporarily directory.${NC}"
+cd $WWW_PATH/themes/custom/drupal_france
+
+echo -e "${LIGHT_GREEN}Generate assets with mode: ${ASSETS_MODE}${NC}"
+npm run-script $ASSETS_MODE
+
+echo -e "${LIGHT_GREEN}Back to the current directory.${NC}"
+cd $CURRENT_PATH

--- a/scripts/generate-assets.sh
+++ b/scripts/generate-assets.sh
@@ -29,6 +29,9 @@ fi
 echo -e "${LIGHT_GREEN}Change temporarily directory.${NC}"
 cd $WWW_PATH/themes/custom/drupal_france
 
+echo -e "${LIGHT_GREEN}Install npm packages.${NC}"
+npm install
+
 echo -e "${LIGHT_GREEN}Generate assets with mode: ${ASSETS_MODE}${NC}"
 npm run-script $ASSETS_MODE
 


### PR DESCRIPTION
J'ai fait un petit script pour compiler les CSS.

J'en avais assez d'avoir soit un autre terminal, soit devoir changer de dossier, lancer la commande npm ou gulp et revenir dans /project pour Composer.

Comme ça au moins si jamais la méthode ou l'emplacement de là où il faut compiler change, on pourra changer le script et les contributeurs pourront garder l'habitude de lancer le même script.

Je me demande si je devrais pas ajouter un `npm install` dedans, histoire d'être sur que si le package-lock.json change, les modules npm soient à jour. Et même pour la première fois qu'un contributeur va compiler.