### PR TITLE
fix sitemap width on mobile

### DIFF
--- a/www/themes/custom/drupal_france/templates/menu/menu--main--drupal-france-footer-sitemap.html.twig
+++ b/www/themes/custom/drupal_france/templates/menu/menu--main--drupal-france-footer-sitemap.html.twig
@@ -32,7 +32,7 @@
   {% if items %}
     {% for row in items|batch(3) %}
       {% if menu_level == 0 %}
-        <ul{{ attributes.addClass('menu-main-footer', 'small-3', 'large-6', 'columns') }}>
+        <ul{{ attributes.addClass('menu-main-footer', 'small-12', 'large-6', 'columns') }}>
       {% else %}
         <ul class="menu">
       {% endif %}


### PR DESCRIPTION
Before:
![before_sitemap](https://user-images.githubusercontent.com/11542186/76700504-90f1c200-66b8-11ea-8361-a9b7ae313fd2.png)

After:
![after_sitemap](https://user-images.githubusercontent.com/11542186/76700516-9bac5700-66b8-11ea-8d9a-00371b275198.png)
